### PR TITLE
feat: EAS-137 adding x-auth-flow header to distinct web and mobile auth

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: Unit Test, Lint, Build
+name: 🩺 Code Health Checkup
 
 on:
   push:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   # Shared setup you can reuse if you want (optional)
   setup:
+    name: 🛠️ Setup dependencies
     runs-on: ubuntu-latest
     outputs:
       cache-hit: ${{ steps.pnpm-cache.outputs.cache-hit }}
@@ -30,6 +31,7 @@ jobs:
         run: pnpm install
 
   test:
+    name: 🧪 Run Unit Tests
     runs-on: ubuntu-latest
     needs: setup
     env:
@@ -53,6 +55,7 @@ jobs:
         run: pnpm test
 
   lint:
+    name: 🧹 Check linting
     runs-on: ubuntu-latest
     needs: setup
     env:
@@ -76,6 +79,7 @@ jobs:
         run: pnpm lint
 
   build:
+    name: 🏗️ Check build
     runs-on: ubuntu-latest
     needs: setup
     env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,11 +9,11 @@ on:
       - develop
 
 jobs:
-  test:
+  # Shared setup you can reuse if you want (optional)
+  setup:
     runs-on: ubuntu-latest
-    env:
-      HUSKY: 0
-
+    outputs:
+      cache-hit: ${{ steps.pnpm-cache.outputs.cache-hit }}
     steps:
       - uses: actions/checkout@v4
 
@@ -29,11 +29,71 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      - name: Ensure unit tests pass
+  test:
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run unit tests
         run: pnpm test
 
-      - name: Ensure proper linting
+  lint:
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run linter
         run: pnpm lint
 
-      - name: Ensure the application builds
+  build:
+    runs-on: ubuntu-latest
+    needs: setup
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run build
         run: pnpm -r build

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from "@nestjs/common";
+import { MiddlewareConsumer, Module } from "@nestjs/common";
 import { ConfigModule, ConfigService } from "@nestjs/config";
 import { CourseModule } from "./courses/courses.module";
 import { PrismaModule } from "nestjs-prisma";
@@ -7,6 +7,8 @@ import { UsersModule } from "./users/users.module";
 import { EmailModule } from "./email/email.module";
 import { SubscriptionsModule } from "./subscriptions/subscriptions.module";
 import configurations from "./config";
+import { RequestMiddleware } from "./middlewares/request.middleware";
+import { AuthController } from "./auth/auth.controller";
 
 @Module({
   imports: [
@@ -38,4 +40,8 @@ import configurations from "./config";
     SubscriptionsModule,
   ],
 })
-export class AppModule {}
+export class AppModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(RequestMiddleware).forRoutes(AuthController);
+  }
+}

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -30,6 +30,7 @@ import UseAuth from "./decorators/auth-with-role.decorator";
 import { UpdateAuthUserDto } from "./dto/auth-user/update-auth-user.dto";
 import AuthFlowHeader from "./decorators/authflow-header.decorator";
 import { CustomRequest } from "src/common/types/custom-request";
+import { RefreshTokenDto } from "./dto/actions/refresh-token.dto";
 
 @Controller("auth")
 export class AuthController {
@@ -127,6 +128,7 @@ export class AuthController {
     status: 200,
     type: IntersectionType(AccessTokenDto, AuthUserDto),
   })
+  @ApiBody({ type: RefreshTokenDto, required: false })
   async refresh(@Req() req: CustomRequest, @Res() res) {
     const response = await this.authService.refresh(req.user.sub);
 

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -28,6 +28,8 @@ import { AuthUserDto } from "./dto/auth-user/auth-user.dto";
 import { AccessTokenDto } from "./dto/actions/access-token.dto";
 import UseAuth from "./decorators/auth-with-role.decorator";
 import { UpdateAuthUserDto } from "./dto/auth-user/update-auth-user.dto";
+import AuthFlowHeader from "./decorators/authflow-header.decorator";
+import { CustomRequest } from "src/common/types/custom-request";
 
 @Controller("auth")
 export class AuthController {
@@ -63,33 +65,53 @@ export class AuthController {
   @UseGuards(LocalAuthGuard)
   @Post("login")
   @ApiBody({ type: SignInDto })
+  @AuthFlowHeader()
   @ApiResponse({
     status: 200,
     description: "Successful login",
     type: IntersectionType(AccessTokenDto, AuthUserDto),
   })
-  async login(@Req() req, @Res() res): Promise<void> {
+  async login(@Req() req: CustomRequest, @Res() res): Promise<void> {
     const twoFactorDiscriminator = await this.authService.login(req.user);
 
     // needs === false for correct type insertion
-    if (twoFactorDiscriminator.requiresOtp === false) {
-      this.setRefreshTokenCookie(res, twoFactorDiscriminator.refreshToken);
-      res.send(twoFactorDiscriminator.user);
-    } else {
+    if (twoFactorDiscriminator.requiresOtp === true) {
       res.send({ requiresOtp: true });
+      return;
     }
+
+    if (req.isWebAuth) {
+      // send refresh token as http only cookie
+      this.setRefreshTokenCookie(res, twoFactorDiscriminator.user.refreshToken);
+      twoFactorDiscriminator.user.refreshToken = undefined;
+      res.send(twoFactorDiscriminator.user);
+      return;
+    }
+
+    res.send(twoFactorDiscriminator.user);
   }
 
   @Post("login/otp")
+  @AuthFlowHeader()
   @ApiResponse({
     status: 200,
     description: "Successful login",
     type: IntersectionType(AccessTokenDto, AuthUserDto),
   })
-  async loginOtp(@Body() otpLoginDto: OtpLoginDto, @Res() res) {
+  async loginOtp(
+    @Body() otpLoginDto: OtpLoginDto,
+    @Req() req: CustomRequest,
+    @Res() res
+  ) {
     const response = await this.authService.loginOtp(otpLoginDto);
 
-    this.setRefreshTokenCookie(res, response.refreshToken);
+    if (req.isWebAuth) {
+      this.setRefreshTokenCookie(res, response.user.refreshToken);
+      response.user.refreshToken = undefined;
+      res.send(response.user);
+      return;
+    }
+
     res.send(response.user);
   }
 
@@ -99,15 +121,21 @@ export class AuthController {
    * @param res The response object.
    */
   @UseGuards(RefreshGuard)
+  @AuthFlowHeader()
   @Post("refresh")
   @ApiResponse({
     status: 200,
     type: IntersectionType(AccessTokenDto, AuthUserDto),
   })
-  async refresh(@Req() req, @Res() res) {
+  async refresh(@Req() req: CustomRequest, @Res() res) {
     const response = await this.authService.refresh(req.user.sub);
 
-    this.setRefreshTokenCookie(res, response.refreshToken);
+    if (req.isWebAuth) {
+      this.setRefreshTokenCookie(res, response.user.refreshToken);
+      response.user.refreshToken = undefined;
+      res.send(response.user);
+      return;
+    }
 
     res.send(response.user);
   }
@@ -231,6 +259,7 @@ export class AuthController {
    * @param res The response object.
    */
   @Put("email")
+  @AuthFlowHeader()
   @ApiResponse({
     status: 200,
     description: "Email confirmation",
@@ -238,11 +267,17 @@ export class AuthController {
   })
   async confirmEmail(
     @Body() emailConfirmDto: EmailConfirmDto,
+    @Req() req: CustomRequest,
     @Res() res
   ): Promise<void> {
     const response = await this.authService.confirmEmail(emailConfirmDto);
 
-    this.setRefreshTokenCookie(res, response.refreshToken);
+    if (req.isWebAuth) {
+      this.setRefreshTokenCookie(res, response.user.refreshToken);
+      response.user.refreshToken = undefined;
+      res.send(response.user);
+      return;
+    }
 
     res.send(response.user);
   }

--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -95,7 +95,6 @@ export class AuthService {
     return {
       requiresOtp: false,
       user: loginResponse.user,
-      refreshToken: loginResponse.refreshToken,
     };
   }
 
@@ -113,14 +112,14 @@ export class AuthService {
     return {
       user: {
         accessToken: this.jwtService.sign(payload),
+        refreshToken: this.jwtService.sign(
+          { sub: user.id },
+          {
+            expiresIn: this.configService.refreshExpiresIn,
+          }
+        ),
         ...user,
       },
-      refreshToken: this.jwtService.sign(
-        { sub: user.id },
-        {
-          expiresIn: this.configService.refreshExpiresIn,
-        }
-      ),
     };
   }
 

--- a/api/src/auth/constants.ts
+++ b/api/src/auth/constants.ts
@@ -1,0 +1,4 @@
+export const AuthFlowHeaderName = "x-auth-flow";
+export const WebAuthFlowName = "web";
+export const RefreshStrategyName = "refresh-jwt";
+export const JwtStrategyName = "jwt";

--- a/api/src/auth/decorators/authflow-header.decorator.ts
+++ b/api/src/auth/decorators/authflow-header.decorator.ts
@@ -1,0 +1,14 @@
+import { applyDecorators } from "@nestjs/common";
+import { ApiHeader } from "@nestjs/swagger";
+import { AuthFlowHeaderName } from "../constants";
+
+export default function AuthFlowHeader(): any {
+  return applyDecorators(
+    ApiHeader({
+      name: AuthFlowHeaderName,
+      description:
+        "The authentication flow to use. 'web' should be specified for web applications",
+      required: false,
+    })
+  );
+}

--- a/api/src/auth/dto/actions/refresh-token.dto.ts
+++ b/api/src/auth/dto/actions/refresh-token.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Expose } from "class-transformer";
+import { IsOptional, IsString } from "class-validator";
+
+export class RefreshTokenDto {
+  @ApiProperty({
+    description:
+      "The refresh token (no need to specify in case of a web auth flow)",
+  })
+  @IsString()
+  @IsOptional()
+  @Expose()
+  refreshToken?: string;
+}

--- a/api/src/auth/strategies/jwt.strategy.ts
+++ b/api/src/auth/strategies/jwt.strategy.ts
@@ -3,8 +3,9 @@ import { ExtractJwt, Strategy } from "passport-jwt";
 import { ConfigType } from "@nestjs/config";
 import { Inject } from "@nestjs/common";
 import jwtConfig from "src/config/jwt.config";
+import { JwtStrategyName } from "../constants";
 
-export class JwtStrategy extends PassportStrategy(Strategy, "jwt") {
+export class JwtStrategy extends PassportStrategy(Strategy, JwtStrategyName) {
   constructor(
     @Inject(jwtConfig.KEY)
     config: ConfigType<typeof jwtConfig>

--- a/api/src/auth/strategies/refresh.strategy.ts
+++ b/api/src/auth/strategies/refresh.strategy.ts
@@ -3,18 +3,27 @@ import { Strategy } from "passport-jwt";
 import { ConfigType } from "@nestjs/config";
 import { Inject } from "@nestjs/common";
 import jwtConfig from "src/config/jwt.config";
+import { AuthFlowHeaderName, RefreshStrategyName } from "../constants";
 
-export class RefreshStrategy extends PassportStrategy(Strategy, "refresh-jwt") {
+export class RefreshStrategy extends PassportStrategy(
+  Strategy,
+  RefreshStrategyName
+) {
   constructor(
     @Inject(jwtConfig.KEY)
     config: ConfigType<typeof jwtConfig>
   ) {
     super({
       jwtFromRequest: (req) => {
-        if (!req || !req.cookies) {
-          return null;
+        if (!req) return null;
+
+        // If it's a web request, the refresh token is in the cookie
+        if (req.headers[AuthFlowHeaderName] === "web" && req.cookies) {
+          return req.cookies["refreshToken"];
         }
-        return req.cookies["refreshToken"];
+
+        // Otherwise, the refresh token is in the body
+        return req?.body?.refreshToken ?? null;
       },
       ignoreExpiration: false,
       secretOrKey: config.secret,

--- a/api/src/auth/types.ts
+++ b/api/src/auth/types.ts
@@ -5,6 +5,5 @@ export type TwoFactorDiscriminator =
   | (LoginResponse & { requiresOtp: false });
 
 export type LoginResponse = {
-  user: AuthUserDto & { accessToken: string };
-  refreshToken: string;
+  user: AuthUserDto & { accessToken: string; refreshToken: string };
 };

--- a/api/src/common/types/custom-request.ts
+++ b/api/src/common/types/custom-request.ts
@@ -1,0 +1,4 @@
+export interface CustomRequest extends Request {
+  isWebAuth: boolean;
+  [key: string]: any;
+}

--- a/api/src/middlewares/request.middleware.ts
+++ b/api/src/middlewares/request.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from "@nestjs/common";
+import { Response, NextFunction } from "express";
+import { AuthFlowHeaderName, WebAuthFlowName } from "src/auth/constants";
+import { CustomRequest } from "src/common/types/custom-request";
+
+@Injectable()
+export class RequestMiddleware implements NestMiddleware {
+  use(req: CustomRequest, res: Response, next: NextFunction) {
+    req.isWebAuth = req.headers[AuthFlowHeaderName] === WebAuthFlowName;
+    next();
+  }
+}

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -529,6 +529,16 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RefreshTokenDto"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "",
@@ -1979,6 +1989,15 @@
           "email",
           "otp"
         ]
+      },
+      "RefreshTokenDto": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "description": "The refresh token (no need to specify in case of a web auth flow)"
+          }
+        }
       },
       "AuthUserDto": {
         "type": "object",

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -126,6 +126,204 @@
         ]
       }
     },
+    "/courses/subscribed": {
+      "get": {
+        "operationId": "CoursesController_findSubscribedCourses",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 10,
+              "type": "number"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "PaginatedResponseOfCourseEntity",
+                  "allOf": [
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CourseEntity"
+                          }
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "type": "number"
+                            },
+                            "hasNextPage": {
+                              "type": "boolean"
+                            },
+                            "currentPage": {
+                              "type": "number"
+                            },
+                            "totalItems": {
+                              "type": "number"
+                            },
+                            "totalPages": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "items",
+                            "hasNextPage",
+                            "currentPage",
+                            "totalItems",
+                            "totalPages"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "meta"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Find all courses to which the logged user is subscribed",
+        "tags": [
+          "Courses"
+        ]
+      }
+    },
+    "/courses/subscribed/{userId}": {
+      "get": {
+        "operationId": "CoursesController_findSubscribedCoursesForUserId",
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 0,
+              "type": "number"
+            }
+          },
+          {
+            "name": "perPage",
+            "required": false,
+            "in": "query",
+            "schema": {
+              "default": 10,
+              "type": "number"
+            }
+          },
+          {
+            "name": "userId",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "title": "PaginatedResponseOfCourseEntity",
+                  "allOf": [
+                    {
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CourseEntity"
+                          }
+                        }
+                      },
+                      "required": [
+                        "data"
+                      ]
+                    },
+                    {
+                      "properties": {
+                        "meta": {
+                          "type": "object",
+                          "properties": {
+                            "items": {
+                              "type": "number"
+                            },
+                            "hasNextPage": {
+                              "type": "boolean"
+                            },
+                            "currentPage": {
+                              "type": "number"
+                            },
+                            "totalItems": {
+                              "type": "number"
+                            },
+                            "totalPages": {
+                              "type": "number"
+                            }
+                          },
+                          "required": [
+                            "items",
+                            "hasNextPage",
+                            "currentPage",
+                            "totalItems",
+                            "totalPages"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "meta"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Find all courses to which the given user is subscribed",
+        "tags": [
+          "Courses"
+        ]
+      }
+    },
     "/courses/{id}": {
       "get": {
         "operationId": "CoursesController_findOne",
@@ -231,7 +429,17 @@
     "/auth/login": {
       "post": {
         "operationId": "AuthController_login",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-auth-flow",
+            "in": "header",
+            "description": "The authentication flow to use. 'web' should be specified for web applications",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -266,7 +474,17 @@
     "/auth/login/otp": {
       "post": {
         "operationId": "AuthController_loginOtp",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-auth-flow",
+            "in": "header",
+            "description": "The authentication flow to use. 'web' should be specified for web applications",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -300,7 +518,17 @@
     "/auth/refresh": {
       "post": {
         "operationId": "AuthController_refresh",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-auth-flow",
+            "in": "header",
+            "description": "The authentication flow to use. 'web' should be specified for web applications",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "",
@@ -585,7 +813,17 @@
       },
       "put": {
         "operationId": "AuthController_confirmEmail",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "x-auth-flow",
+            "in": "header",
+            "description": "The authentication flow to use. 'web' should be specified for web applications",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {

--- a/packages/auth-context/src/ApiContext/ApiContextProvider.tsx
+++ b/packages/auth-context/src/ApiContext/ApiContextProvider.tsx
@@ -20,6 +20,7 @@ export default function ApiContextProvider(props: ApiContextProviderProps) {
       baseUrl: props.apiBaseUrl,
       securityWorker: () => ({
         headers: {
+          "x-auth-flow": "web",
           Authorization: `Bearer ${accessToken}`,
         },
       }),

--- a/packages/auth-context/src/ApiContext/custom-fetch.ts
+++ b/packages/auth-context/src/ApiContext/custom-fetch.ts
@@ -33,6 +33,7 @@ const customFetch = async (
   const api = new Api({
     baseUrl: apiBaseUrl,
     securityWorker: () => ({
+      "x-auth-flow": "web",
       credentials: "include", // Ensures cookies are sent with the request to the refresh endpoint.
     }),
   });

--- a/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
+++ b/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
@@ -27,6 +27,12 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     () =>
       new Api({
         baseUrl: props.apiBaseUrl,
+        securityWorker: () => ({
+          credentials: "include",
+          headers: {
+            "x-auth-flow": "web",
+          },
+        }),
       }).auth,
 
     [props.apiBaseUrl]
@@ -50,10 +56,7 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
    * @param password - User's password
    */
   const login = async (email: string, password: string) => {
-    const response = await apiInstance.authControllerLogin(
-      { email, password },
-      { credentials: "include" } // Ensure cookies are sent for authentication
-    );
+    const response = await apiInstance.authControllerLogin({ email, password });
 
     if (response.data.requiresOtp) {
       setOtpStatus({ needsOtp: true, email });
@@ -76,10 +79,10 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
       throw new Error("No OTP required");
     }
 
-    const response = await apiInstance.authControllerLoginOtp(
-      { email: otpStatus.email, otp },
-      { credentials: "include" }
-    );
+    const response = await apiInstance.authControllerLoginOtp({
+      email: otpStatus.email,
+      otp,
+    });
 
     // Update the token and user state with the server's response
     updateAccessToken(response.data.accessToken);
@@ -96,7 +99,6 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     const response = await apiInstance.authControllerUpdateUserProfile(
       { twoFactorEnabled: status },
       {
-        credentials: "include",
         headers: {
           Authorization: `Bearer ${accessToken}`, // Include the access token for authenticated logout
         },
@@ -112,7 +114,6 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
    */
   const logout = async () => {
     await apiInstance.authControllerLogout({
-      credentials: "include", // Ensure cookies are included for server-side session handling
       headers: {
         Authorization: `Bearer ${accessToken}`, // Include the access token for authenticated logout
       },
@@ -132,9 +133,7 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
   const updateEmail = async (email: string, userId: string, token: string) => {
     const payload = { email, userId, token };
 
-    const response = await apiInstance.authControllerConfirmEmail(payload, {
-      credentials: "include",
-    });
+    const response = await apiInstance.authControllerConfirmEmail(payload);
 
     if (response.ok) {
       updateAccessToken(response.data.accessToken);

--- a/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
+++ b/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
@@ -24,6 +24,7 @@ export const useInitialRefresh = (props: UseInitialRefreshProps) => {
       try {
         const response = await props.apiInstance.authControllerRefresh({
           credentials: "include",
+          headers: { "x-auth-flow": "web" },
         });
 
         if (response.ok) {

--- a/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
+++ b/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
@@ -22,10 +22,13 @@ export const useInitialRefresh = (props: UseInitialRefreshProps) => {
 
     const refresh = async () => {
       try {
-        const response = await props.apiInstance.authControllerRefresh(null, {
-          credentials: "include",
-          headers: { "x-auth-flow": "web" },
-        });
+        const response = await props.apiInstance.authControllerRefresh(
+          undefined,
+          {
+            credentials: "include",
+            headers: { "x-auth-flow": "web" },
+          }
+        );
 
         if (response.ok) {
           props.updateAccessToken(response.data.accessToken);

--- a/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
+++ b/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
@@ -22,7 +22,7 @@ export const useInitialRefresh = (props: UseInitialRefreshProps) => {
 
     const refresh = async () => {
       try {
-        const response = await props.apiInstance.authControllerRefresh({
+        const response = await props.apiInstance.authControllerRefresh(null, {
           credentials: "include",
           headers: { "x-auth-flow": "web" },
         });


### PR DESCRIPTION
This PR introduces the differentiation between a web authentication and a mobile authentication. The necessity for this originated from the fact that the actual authentication flow is providing refresh tokens as http-only cookies, which cannot be supported in the case of mobile applications. 

By adding an `x-auth-flow` header to authentication requests, it is now possible to inform the api whether the requests needs to be treated as a web or mobile request.

**No actions should be taken** since the web application client has already been updated to provide the specified header and since the non-cookie-based approach is used when the header is not specified.

## Non web request

The following request

```bash
curl -X POST \
        https://api.easymotion.devlocal/auth/login \
        -d "{\"email\": \"example@example.com\", \"password\": \"password\"}"
```

will return

```json
{
  "accessToken": ".....",
  "refreshToken": "....",
  ...
}
```

## Web Request

The following request

```bash
curl -X POST \
        https://api.easymotion.devlocal/auth/login \
        -H "x-auth-flow: web" \
        -d "{\"email\": \"example@example.com\", \"password\": \"password\"}"
```

will return

```json
{
  "accessToken": ".....",
  ...
}
```

the refresh token will be set as an http-only to the user browser.

## Testing on swagger

SwaggerUI now provides a box to type the additional header in authentication requests. Since SwaggerUI runs on a web application both options can be tested. By specifying `web` on the login request, the refresh token won't be provided in the response and will be set as an http-only cookie. By executing a refresh request (still specifying `web` as the auth flow header), the token will be correctly refreshed.

Otherwise, by not providing a value for the auth flow header, both access token and refresh token will be provided in the login response and the refresh token will need to be passed in the refresh request body in order to refresh the tokens.

