### PR TITLE
fix: updated login response

### DIFF
--- a/api/src/auth/dto/actions/access-token.dto.ts
+++ b/api/src/auth/dto/actions/access-token.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Expose } from "class-transformer";
-import { IsBoolean, IsString } from "class-validator";
+import { IsOptional, IsString } from "class-validator";
 
 export class AccessTokenDto {
   @ApiProperty({
@@ -11,9 +11,10 @@ export class AccessTokenDto {
   accessToken: string;
 
   @ApiProperty({
-    description: "Indicates if secondary OTP step is required",
+    description: "The access token (if not using a web auth flow)",
   })
-  @IsBoolean()
+  @IsString()
   @Expose()
-  requiresOtp: boolean;
+  @IsOptional()
+  refreshToken?: string;
 }

--- a/api/src/auth/dto/auth-user/auth-response.dto.ts
+++ b/api/src/auth/dto/auth-user/auth-response.dto.ts
@@ -1,0 +1,30 @@
+import { IsBoolean, IsOptional } from "class-validator";
+import { AuthUserDto } from "./auth-user.dto";
+import { Expose, Type } from "class-transformer";
+import { ApiProperty } from "@nestjs/swagger";
+import { AccessTokenDto } from "../actions/access-token.dto";
+
+export class AuthResponseDto {
+  @ApiProperty({ description: "User related data" })
+  @Expose()
+  @IsOptional()
+  @Type(() => AuthUserDto)
+  user?: AuthUserDto;
+
+  @ApiProperty({ description: "Access token and, eventually, refresh token" })
+  @Expose()
+  @IsOptional()
+  @Type(() => AccessTokenDto)
+  tokens?: AccessTokenDto;
+
+  @ApiProperty({
+    description: "Indicates if secondary OTP step is required",
+  })
+  @IsBoolean()
+  @Expose()
+  requiresOtp: boolean;
+
+  constructor(partial: Partial<AuthResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/api/src/auth/types.ts
+++ b/api/src/auth/types.ts
@@ -1,9 +1,0 @@
-import { AuthUserDto } from "./dto/auth-user/auth-user.dto";
-
-export type TwoFactorDiscriminator =
-  | { requiresOtp: true }
-  | (LoginResponse & { requiresOtp: false });
-
-export type LoginResponse = {
-  user: AuthUserDto & { accessToken: string; refreshToken: string };
-};

--- a/openapi/schema.json
+++ b/openapi/schema.json
@@ -369,7 +369,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntersectionAccessTokenDtoAuthUserDto"
+                  "$ref": "#/components/schemas/AuthResponseDto"
                 }
               }
             }
@@ -414,7 +414,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntersectionAccessTokenDtoAuthUserDto"
+                  "$ref": "#/components/schemas/AuthResponseDto"
                 }
               }
             }
@@ -459,7 +459,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntersectionAccessTokenDtoAuthUserDto"
+                  "$ref": "#/components/schemas/AuthResponseDto"
                 }
               }
             }
@@ -504,7 +504,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntersectionAccessTokenDtoAuthUserDto"
+                  "$ref": "#/components/schemas/AuthResponseDto"
                 }
               }
             }
@@ -811,7 +811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/IntersectionAccessTokenDtoAuthUserDto"
+                  "$ref": "#/components/schemas/AuthResponseDto"
                 }
               }
             }
@@ -1957,117 +1957,6 @@
           "password"
         ]
       },
-      "IntersectionAccessTokenDtoAuthUserDto": {
-        "type": "object",
-        "properties": {
-          "accessToken": {
-            "type": "string",
-            "description": "The access token"
-          },
-          "requiresOtp": {
-            "type": "boolean",
-            "description": "Indicates if secondary OTP step is required"
-          },
-          "id": {
-            "type": "string",
-            "description": "Unique user identifier (UUID)",
-            "example": "b3bf4d18-8dd0-43a1-b1da-fd3f7b9553a1"
-          },
-          "email": {
-            "type": "string",
-            "format": "email",
-            "description": "Email address of the user",
-            "example": "user@example.com"
-          },
-          "firstName": {
-            "type": "string",
-            "description": "User first name",
-            "example": "John"
-          },
-          "middleName": {
-            "type": "string",
-            "nullable": true,
-            "description": "User middle name",
-            "example": "Alexander"
-          },
-          "lastName": {
-            "type": "string",
-            "description": "User last name",
-            "example": "Doe"
-          },
-          "phoneNumber": {
-            "type": "string",
-            "nullable": true,
-            "description": "User phone number",
-            "example": "+1234567890"
-          },
-          "birthDate": {
-            "type": "string",
-            "nullable": true,
-            "description": "User birth date",
-            "example": "1990-01-01"
-          },
-          "role": {
-            "type": "string",
-            "description": "User role in the system",
-            "enum": [
-              "USER",
-              "ADMIN",
-              "PHYSIOTHERAPIST"
-            ],
-            "default": "USER"
-          },
-          "isEmailVerified": {
-            "type": "boolean",
-            "description": "Indicates if the user email has been verified",
-            "default": false,
-            "example": false
-          },
-          "twoFactorEnabled": {
-            "type": "boolean",
-            "description": "Indicates if two-factor authentication is enabled",
-            "default": false
-          }
-        },
-        "required": [
-          "accessToken",
-          "requiresOtp",
-          "id",
-          "email",
-          "firstName",
-          "lastName",
-          "role",
-          "isEmailVerified",
-          "twoFactorEnabled"
-        ]
-      },
-      "OtpLoginDto": {
-        "type": "object",
-        "properties": {
-          "email": {
-            "type": "string",
-            "format": "email",
-            "description": "User email used for first login step"
-          },
-          "otp": {
-            "type": "string",
-            "description": "One-time password"
-          }
-        },
-        "required": [
-          "email",
-          "otp"
-        ]
-      },
-      "RefreshTokenDto": {
-        "type": "object",
-        "properties": {
-          "refreshToken": {
-            "type": "string",
-            "description": "The refresh token (no need to specify in case of a web auth flow)"
-          }
-        }
-      },
       "AuthUserDto": {
         "type": "object",
         "properties": {
@@ -2141,6 +2030,77 @@
           "isEmailVerified",
           "twoFactorEnabled"
         ]
+      },
+      "AccessTokenDto": {
+        "type": "object",
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "description": "The access token"
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "The access token (if not using a web auth flow)"
+          }
+        },
+        "required": [
+          "accessToken"
+        ]
+      },
+      "AuthResponseDto": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "description": "User related data",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AuthUserDto"
+              }
+            ]
+          },
+          "tokens": {
+            "description": "Access token and, eventually, refresh token",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AccessTokenDto"
+              }
+            ]
+          },
+          "requiresOtp": {
+            "type": "boolean",
+            "description": "Indicates if secondary OTP step is required"
+          }
+        },
+        "required": [
+          "requiresOtp"
+        ]
+      },
+      "OtpLoginDto": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "User email used for first login step"
+          },
+          "otp": {
+            "type": "string",
+            "description": "One-time password"
+          }
+        },
+        "required": [
+          "email",
+          "otp"
+        ]
+      },
+      "RefreshTokenDto": {
+        "type": "object",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "description": "The refresh token (no need to specify in case of a web auth flow)"
+          }
+        }
       },
       "UpdateAuthUserDto": {
         "type": "object",

--- a/packages/auth-context/src/ApiContext/custom-fetch.ts
+++ b/packages/auth-context/src/ApiContext/custom-fetch.ts
@@ -48,16 +48,16 @@ const customFetch = async (
      * - The `onAccessTokenUpdate` callback is called to update the application's state with the new token.
      * - The original request is retried with the updated `Authorization` header containing the new token.
      */
-    const { accessToken } = fetchResponse.data.tokens;
+    const tokens = fetchResponse.data.tokens;
 
-    onAccessTokenUpdate(accessToken); // Update the access token in the application state.
+    onAccessTokenUpdate(tokens?.accessToken ?? ""); // Update the access token in the application state.
 
     // Retry the original request with the new access token.
     return fetch(input, {
       ...init,
       headers: {
         ...init?.headers,
-        Authorization: `Bearer ${accessToken}`, // Set the new token in the headers.
+        Authorization: `Bearer ${tokens?.accessToken}`, // Set the new token in the headers.
       },
     });
   }

--- a/packages/auth-context/src/ApiContext/custom-fetch.ts
+++ b/packages/auth-context/src/ApiContext/custom-fetch.ts
@@ -48,7 +48,7 @@ const customFetch = async (
      * - The `onAccessTokenUpdate` callback is called to update the application's state with the new token.
      * - The original request is retried with the updated `Authorization` header containing the new token.
      */
-    const { accessToken } = fetchResponse.data;
+    const { accessToken } = fetchResponse.data.tokens;
 
     onAccessTokenUpdate(accessToken); // Update the access token in the application state.
 

--- a/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
+++ b/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
@@ -66,8 +66,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
       return { needsOtp: true };
     }
     // Update the token and user state with the server's response
-    updateAccessToken(response.data.tokens.accessToken);
-    setUser(response.data.user);
+    updateAccessToken(response.data.tokens?.accessToken ?? "");
+    if (response.data.user) setUser(response.data.user);
     return { needsOtp: false };
   };
 
@@ -88,8 +88,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     });
 
     // Update the token and user state with the server's response
-    updateAccessToken(response.data.tokens.accessToken);
-    setUser(response.data.user);
+    updateAccessToken(response.data.tokens?.accessToken ?? "");
+    if (response.data.user) setUser(response.data.user);
     setOtpStatus({ needsOtp: false, email: "" });
   };
 
@@ -139,8 +139,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     const response = await apiInstance.authControllerConfirmEmail(payload);
 
     if (response.ok) {
-      updateAccessToken(response.data.tokens.accessToken);
-      setUser(response.data.user);
+      updateAccessToken(response.data.tokens?.accessToken ?? "");
+      if (response.data.user) setUser(response.data.user);
     }
   };
 

--- a/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
+++ b/packages/auth-context/src/AuthContext/AuthContextProvider.tsx
@@ -66,8 +66,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
       return { needsOtp: true };
     }
     // Update the token and user state with the server's response
-    updateAccessToken(response.data.accessToken);
-    setUser(response.data);
+    updateAccessToken(response.data.tokens.accessToken);
+    setUser(response.data.user);
     return { needsOtp: false };
   };
 
@@ -88,8 +88,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     });
 
     // Update the token and user state with the server's response
-    updateAccessToken(response.data.accessToken);
-    setUser(response.data);
+    updateAccessToken(response.data.tokens.accessToken);
+    setUser(response.data.user);
     setOtpStatus({ needsOtp: false, email: "" });
   };
 
@@ -139,8 +139,8 @@ export default function AuthContextProvider(props: AuthContextProviderProps) {
     const response = await apiInstance.authControllerConfirmEmail(payload);
 
     if (response.ok) {
-      updateAccessToken(response.data.accessToken);
-      setUser(response.data);
+      updateAccessToken(response.data.tokens.accessToken);
+      setUser(response.data.user);
     }
   };
 

--- a/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
+++ b/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
@@ -31,8 +31,8 @@ export const useInitialRefresh = (props: UseInitialRefreshProps) => {
         );
 
         if (response.ok) {
-          props.updateAccessToken(response.data.accessToken);
-          props.setUser(response.data);
+          props.updateAccessToken(response.data.tokens.accessToken);
+          props.setUser(response.data.user);
         }
       } catch {
         props.updateAccessToken(null);

--- a/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
+++ b/packages/auth-context/src/AuthContext/useInitialRefresh.tsx
@@ -31,8 +31,8 @@ export const useInitialRefresh = (props: UseInitialRefreshProps) => {
         );
 
         if (response.ok) {
-          props.updateAccessToken(response.data.tokens.accessToken);
-          props.setUser(response.data.user);
+          props.updateAccessToken(response.data.tokens?.accessToken ?? "");
+          if (response.data.user) props.setUser(response.data.user);
         }
       } catch {
         props.updateAccessToken(null);


### PR DESCRIPTION
The PR updates login response so that it consists of 

```
{
  user: AuthUserDto, // optional
  tokens: {  // optional
    accessToken: string,
    refreshToken: string // optional
  },
  requiresOtp: boolean
}
```

supposing that authentication requires otp step we get response

```
{
  user: null,
  tokens: null,
  requiresOtp: true
}
```

the final login response returns instead

```
{
  requiresOtp: false,
  user: {...},
  tokens: {
    accessToken: "...",
    refreshToken: "...", // or null if we are using x-auth-flow web header
  }
}
```

The response is documented on Swagger