### PR TITLE
feat(webapp): error boundary

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.1.0)
       react-hook-form:
         specifier: ^7.55.0
         version: 7.55.0(react@19.1.0)
@@ -4139,6 +4142,11 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
 
   react-hook-form@7.55.0:
     resolution: {integrity: sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==}
@@ -9455,6 +9463,11 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-error-boundary@5.0.0(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      react: 19.1.0
 
   react-hook-form@7.55.0(react@19.1.0):
     dependencies:

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -30,6 +30,7 @@
     "notistack": "^3.0.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-error-boundary": "^5.0.0",
     "react-hook-form": "^7.55.0",
     "react-phone-input-2": "^2.15.1",
     "react-router": "^7.5.0",

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -8,6 +8,8 @@ import { ApiContextProvider } from "@easymotion/auth-context";
 import { AuthContextProvider } from "@easymotion/auth-context";
 import { LocalizationProvider } from "@mui/x-date-pickers";
 import { AdapterLuxon } from "@mui/x-date-pickers/AdapterLuxon";
+import { ErrorBoundary } from "react-error-boundary";
+import { GlobalErrorFallback } from "./components/fallbacks/GlobalErrorFallback";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -35,7 +37,9 @@ export default function App() {
                   <SnackbarCloseButton snackbarKey={snackbarKey} />
                 )}
               >
-                <Router />
+                <ErrorBoundary FallbackComponent={GlobalErrorFallback}>
+                  <Router />
+                </ErrorBoundary>
               </SnackbarProvider>
             </DialogContextProvider>
             <ReactQueryDevtools buttonPosition="bottom-left" />

--- a/webapp/src/components/fallbacks/GlobalErrorFallback.tsx
+++ b/webapp/src/components/fallbacks/GlobalErrorFallback.tsx
@@ -9,9 +9,8 @@ import {
 } from "@mui/material";
 
 export function GlobalErrorFallback({ error }: FallbackProps) {
-  const handleGoHome = () => {
-    window.location.href = "/";
-  };
+  // no react router since this is higher in the tree
+  const handleGoHome = () => (window.location.href = "/");
 
   return (
     <Box

--- a/webapp/src/components/fallbacks/GlobalErrorFallback.tsx
+++ b/webapp/src/components/fallbacks/GlobalErrorFallback.tsx
@@ -1,0 +1,82 @@
+import { FallbackProps } from "react-error-boundary";
+import {
+  Box,
+  Typography,
+  Button,
+  Container,
+  Stack,
+  Paper,
+} from "@mui/material";
+
+export function GlobalErrorFallback({ error }: FallbackProps) {
+  const handleGoHome = () => {
+    window.location.href = "/";
+  };
+
+  return (
+    <Box
+      sx={{
+        height: "100svh",
+        width: "100%",
+        backgroundImage:
+          "linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)), url(/hero.jpg)",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        backgroundRepeat: "no-repeat",
+        color: "text.primary",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper elevation={3} sx={{ p: 4, borderRadius: 2 }}>
+          <Stack spacing={3} alignItems="center" textAlign="center">
+            <Typography variant="h4" color="primary">
+              Ops... qualcosa è andato storto 🤦‍♂️
+            </Typography>
+
+            <Typography variant="body1" color="text.secondary">
+              Potrebbe trattarsi di un errore temporaneo oppure di un problema
+              inatteso nell'applicazione. Se stavi facendo qualcosa di
+              importante, ci dispiace 🙇‍♂️
+            </Typography>
+
+            <Box
+              sx={{
+                width: "100%",
+                bgcolor: "#f5f5f5",
+                border: "1px solid #ccc",
+                borderRadius: 1,
+                p: 2,
+                mt: 1,
+                fontSize: "0.875rem",
+                fontFamily: "monospace",
+                color: "error.main",
+                overflowX: "auto",
+                maxHeight: 200,
+              }}
+            >
+              {error.message || "Errore sconosciuto."}
+            </Box>
+
+            <Typography variant="caption" color="text.secondary" sx={{ mt: 1 }}>
+              Se l'errore persiste, invia questo messaggio all'assistenza di{" "}
+              <strong>EasyMotion</strong>.
+            </Typography>
+
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleGoHome}
+              size="large"
+              sx={{ mt: 2 }}
+            >
+              Torna alla Home
+            </Button>
+          </Stack>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}


### PR DESCRIPTION
I've added a global React error boundary to the app — it's something we should start leveraging more consistently to handle unexpected errors gracefully.

For now, it works as a global exception catcher, displaying a clean layout with the error message (and stack trace if needed). This gives users a friendlier experience when something breaks, rather than a blank screen.

In the future, we can add more specific boundaries deeper in the component tree to handle particular cases (like form errors, data fetching issues, etc.) in a more contextual way — but this is a solid starting point.

Make sure to run `pnpm install`, since it includes a new dependency: [react-error-boundary](https://www.npmjs.com/package/react-error-boundary).

Here’s an example of what it looks like when an exception is thrown from a component:

![image](https://github.com/user-attachments/assets/19a34e79-c649-4705-97e9-b45dda179807)

Note: The error message shown is exactly what gets thrown. In this case I was throwing an exception with that message from a component.

Hope you like it  🚀