### PR TITLE
fix(api): seed for production

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -17,6 +17,7 @@
     "start:prod": "node dist/src/main",
     "start:prod:migrate": "prisma migrate deploy && npm run start:prod",
     "seed": "ts-node prisma/seed.ts",
+    "seed:prod": "node dist/prisma/seed",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
This should finally resolve the long-standing issue where the production API couldn’t run the seeding script.

Since we often drop the database (for good reasons), being able to re-seed dev data in production is super useful — and now it works as expected.

It’s a simple fix (most related issues were already solved during the pnpm migration). I just never got around to changing literally one line of code because I was always caught up with something else. My bad 😅