### PR TITLE
feat(api): email notification for course update

### DIFF
--- a/api/src/courses/courses.controller.spec.ts
+++ b/api/src/courses/courses.controller.spec.ts
@@ -12,10 +12,13 @@ import { Course, CourseLevel, PaymentRecurrence } from "@prisma/client";
 import { plainToInstance } from "class-transformer";
 import { CompressionService } from "src/assets/utilities/compression.service";
 import { ASSETS_SERVICE } from "src/assets/assets.interface";
+import { EmailService } from "src/email/email.service";
+import frontendConfig from "src/config/frontend.config";
 
 describe("CoursesController", () => {
   let controller: CoursesController;
   let prismaMock: any;
+  let mockupEmailService: any;
 
   beforeEach(async () => {
     // Mock PrismaService
@@ -31,6 +34,9 @@ describe("CoursesController", () => {
       courseSession: {
         findMany: jest.fn(),
       },
+      subscription: {
+        findMany: jest.fn(),
+      },
     };
 
     const mockupCompressionService = {
@@ -41,6 +47,10 @@ describe("CoursesController", () => {
       uploadBuffer: jest.fn(),
       deleteFile: jest.fn(),
       getFileStream: jest.fn(),
+    };
+
+    mockupEmailService = {
+      sendEmail: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -58,6 +68,16 @@ describe("CoursesController", () => {
         {
           provide: CompressionService,
           useValue: mockupCompressionService,
+        },
+        {
+          provide: EmailService,
+          useValue: mockupEmailService,
+        },
+        {
+          provide: frontendConfig.KEY,
+          useValue: {
+            url: "http://localhost:3000",
+          },
         },
       ],
     }).compile();
@@ -344,7 +364,8 @@ describe("CoursesController", () => {
     prismaMock.courseSession.findMany.mockResolvedValue([]);
     prismaMock.course.findUniqueOrThrow.mockResolvedValue(updatedCourse);
     prismaMock.course.update.mockResolvedValue(updatedCourse);
-
+    prismaMock.subscription.findMany.mockResolvedValue([]);
+    mockupEmailService.sendEmail.mockResolvedValue(undefined);
     const result = await controller.update(id, dto);
 
     // Check that update was called with correct ID

--- a/api/src/courses/courses.controller.ts
+++ b/api/src/courses/courses.controller.ts
@@ -128,7 +128,7 @@ export class CoursesController {
 
     const subscribers = await this.coursesService.getCourseSubscribers(id);
 
-    await Promise.all(
+    await Promise.allSettled(
       subscribers.map((subscriber) =>
         this.emailService.sendEmail(
           subscriber.patient.applicationUser.email,

--- a/api/src/courses/courses.controller.ts
+++ b/api/src/courses/courses.controller.ts
@@ -10,6 +10,7 @@ import {
   Req,
   UploadedFile,
   ParseFilePipeBuilder,
+  Inject,
 } from "@nestjs/common";
 import { CoursesService } from "./courses.service";
 import { CreateCourseDto } from "./dto/create-course.dto";
@@ -23,12 +24,18 @@ import { Role } from "@prisma/client";
 import { CourseQueryFilter } from "./dto/filters/course-query-filter.dto";
 import { ApiFileBody } from "src/common/decorators/api-file-body.decorator";
 import { CompressionService } from "src/assets/utilities/compression.service";
+import { EmailService } from "src/email/email.service";
+import { ConfigType } from "@nestjs/config";
+import frontendConfig from "src/config/frontend.config";
 
 @Controller("courses")
 export class CoursesController {
   constructor(
     private readonly coursesService: CoursesService,
-    private readonly imageCompressionService: CompressionService
+    private readonly emailService: EmailService,
+    private readonly imageCompressionService: CompressionService,
+    @Inject(frontendConfig.KEY)
+    private readonly config: ConfigType<typeof frontendConfig>
   ) {}
 
   /**
@@ -110,8 +117,29 @@ export class CoursesController {
   @Put(":id")
   @ApiOkResponse({ type: CourseDto })
   @UseAuth([Role.PHYSIOTHERAPIST])
-  update(@Param("id") id: string, @Body() updateCoursesDto: UpdateCourseDto) {
-    return this.coursesService.update(id, updateCoursesDto);
+  async update(
+    @Param("id") id: string,
+    @Body() updateCoursesDto: UpdateCourseDto
+  ) {
+    const updatedCourse = await this.coursesService.update(
+      id,
+      updateCoursesDto
+    );
+
+    const subscribers = await this.coursesService.getCourseSubscribers(id);
+
+    await Promise.all(
+      subscribers.map((subscriber) =>
+        this.emailService.sendEmail(
+          subscriber.patient.applicationUser.email,
+          "Corso aggiornato",
+          `Il corso ${updatedCourse.name} al quale sei iscritto è stato aggiornato.<br/>
+          <a href="${this.config.url}/details/${id}">Visualizza le modifiche.</a>`
+        )
+      )
+    );
+
+    return updatedCourse;
   }
 
   /**

--- a/api/src/courses/courses.module.ts
+++ b/api/src/courses/courses.module.ts
@@ -3,9 +3,10 @@ import { CoursesService } from "./courses.service";
 import { CoursesController } from "./courses.controller";
 import { PrismaService } from "nestjs-prisma";
 import { AssetsModule } from "src/assets/assets.module";
+import { EmailModule } from "src/email/email.module";
 
 @Module({
-  imports: [AssetsModule],
+  imports: [AssetsModule, EmailModule],
   controllers: [CoursesController],
   providers: [CoursesService, PrismaService],
   exports: [CoursesService],

--- a/api/src/courses/courses.service.ts
+++ b/api/src/courses/courses.service.ts
@@ -314,6 +314,24 @@ export class CoursesService {
   }
 
   /**
+   * Get all subscribers for a course
+   * @param courseId the id of the course
+   * @returns all subscribers for the course
+   */
+  getCourseSubscribers(courseId: string) {
+    return this.prismaService.subscription.findMany({
+      where: { course_id: courseId },
+      include: {
+        patient: {
+          include: {
+            applicationUser: true,
+          },
+        },
+      },
+    });
+  }
+
+  /**
    * Find courses to which the given userId is subscribed
    * @param userId the id of the logged in user
    * @param pagination the pagination filter


### PR DESCRIPTION
The PR implements an email notification which is automatically sent to the subscribers of a course when the properties of the latter change.

No changes to the DB but in case you come from other branches you may need to run `pnpm blast` just to ensure the db is in sync.